### PR TITLE
Add Alt+Right Bracket waypoint deletion

### DIFF
--- a/mod/AccessibilityMod.csproj
+++ b/mod/AccessibilityMod.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <!-- MelonLoader references instead of PackageReference -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(DISCO_ELYSIUM_PATH)' != ''">
     <Reference Include="MelonLoader">
       <HintPath>$(DISCO_ELYSIUM_PATH)\MelonLoader\net6\MelonLoader.dll</HintPath>
       <Private>False</Private>
@@ -40,7 +40,7 @@
     </Reference>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DISCO_ELYSIUM_PATH)' != ''">
     <!-- Game assemblies from Il2CppAssemblies directory -->
     <Reference Include="Assembly-CSharp">
       <HintPath>$(DISCO_ELYSIUM_PATH)\MelonLoader\Il2CppAssemblies\Assembly-CSharp.dll</HintPath>

--- a/mod/Input/InputManager.cs
+++ b/mod/Input/InputManager.cs
@@ -18,6 +18,31 @@ namespace AccessibilityMod.Input
 
         public void HandleInput()
         {
+            if (navigationSystem.IsWaypointNamingActive)
+            {
+                string typedCharacters = UnityEngine.Input.inputString;
+                if (!string.IsNullOrEmpty(typedCharacters))
+                {
+                    navigationSystem.HandleWaypointNamingInput(typedCharacters);
+                }
+
+                bool confirm = UnityEngine.Input.GetKeyDown(KeyCode.Return) || UnityEngine.Input.GetKeyDown(KeyCode.KeypadEnter);
+                bool cancel = UnityEngine.Input.GetKeyDown(KeyCode.Escape);
+
+                if (confirm)
+                {
+                    navigationSystem.ConfirmWaypointNaming();
+                }
+                else if (cancel)
+                {
+                    navigationSystem.CancelWaypointNaming();
+                }
+
+                Il2CppInControl.InputManager.ClearInputState();
+                UnityEngine.Input.ResetInputAxes();
+                return;
+            }
+
             // On-demand current selection announcement: Grave/Tilde key (`)
             if (UnityEngine.Input.GetKeyDown(KeyCode.BackQuote))
             {
@@ -36,14 +61,37 @@ namespace AccessibilityMod.Input
                 navigationSystem.ScanSceneByDistance();
             }
             
-            // Category selection keys (safe punctuation)
-            if (UnityEngine.Input.GetKeyDown(KeyCode.LeftBracket))  // [
+            bool leftBracketDown = UnityEngine.Input.GetKeyDown(KeyCode.LeftBracket);
+            bool rightBracketDown = UnityEngine.Input.GetKeyDown(KeyCode.RightBracket);
+            bool ctrlHeld = UnityEngine.Input.GetKey(KeyCode.LeftControl) || UnityEngine.Input.GetKey(KeyCode.RightControl);
+            bool altHeld = UnityEngine.Input.GetKey(KeyCode.LeftAlt) || UnityEngine.Input.GetKey(KeyCode.RightAlt);
+
+            // Category selection keys (safe punctuation) + modifiers for waypoints
+            if (leftBracketDown)
             {
-                navigationSystem.SelectCategory(ObjectCategory.NPCs);
+                if (altHeld)
+                {
+                    navigationSystem.StartWaypointCreation();
+                }
+                else if (ctrlHeld)
+                {
+                    navigationSystem.FocusWaypoints();
+                }
+                else
+                {
+                    navigationSystem.SelectCategory(ObjectCategory.NPCs);
+                }
             }
-            else if (UnityEngine.Input.GetKeyDown(KeyCode.RightBracket))  // ]
+            else if (rightBracketDown)  // ]
             {
-                navigationSystem.SelectCategory(ObjectCategory.Locations);
+                if (altHeld)
+                {
+                    navigationSystem.DeleteCurrentWaypoint();
+                }
+                else
+                {
+                    navigationSystem.SelectCategory(ObjectCategory.Locations);
+                }
             }
             else if (UnityEngine.Input.GetKeyDown(KeyCode.Backslash))  // \
             {

--- a/mod/Navigation/SmartNavigationSystem.cs
+++ b/mod/Navigation/SmartNavigationSystem.cs
@@ -5,26 +5,49 @@ using UnityEngine;
 using Il2Cpp;
 using Il2CppFortressOccident;
 using AccessibilityMod.Utils;
+using UnityEngine.SceneManagement;
 using MelonLoader;
 
 namespace AccessibilityMod.Navigation
 {
+    public enum NavigationFocus
+    {
+        ObjectCategories,
+        Waypoints
+    }
+
     public class SmartNavigationSystem
     {
         private readonly NavigationStateManager stateManager;
         private readonly MovementController movementController;
+        private readonly WaypointManager waypointManager;
+
+        private NavigationFocus currentFocus = NavigationFocus.ObjectCategories;
+        private WaypointNamingSession namingSession;
 
         public NavigationStateManager StateManager => stateManager;
         public MovementController MovementController => movementController;
+        public WaypointManager WaypointManager => waypointManager;
+        public bool IsWaypointNamingActive => namingSession?.IsActive ?? false;
+        public bool IsWaypointFocus => currentFocus == NavigationFocus.Waypoints;
 
         public SmartNavigationSystem()
         {
             stateManager = new NavigationStateManager();
             movementController = new MovementController();
+            waypointManager = new WaypointManager();
         }
 
         public void SelectCategory(ObjectCategory category)
         {
+            if (IsWaypointNamingActive)
+            {
+                TolkScreenReader.Instance.Speak("Finish naming your waypoint first. Press Enter to save or Escape to cancel.", true);
+                return;
+            }
+
+            currentFocus = NavigationFocus.ObjectCategories;
+
             try
             {
                 MelonLogger.Msg($"[SMART NAV] Selecting category: {category}");
@@ -33,7 +56,7 @@ namespace AccessibilityMod.Navigation
                 var registry = MouseOverHighlight.registry;
                 if (registry == null || registry.Count == 0)
                 {
-                    TolkScreenReader.Instance.Speak("No objects available for selection", true);
+                    TolkScreenReader.Instance.Speak("No objects available for selection.", true);
                     return;
                 }
                 
@@ -50,7 +73,7 @@ namespace AccessibilityMod.Navigation
                 
                 // Announce category contents
                 var navInfo = stateManager.GetCurrentNavigationInfo(playerPos);
-                string announcement = $"{category}: " +navInfo.FormatAnnouncement();
+                string announcement = $"{category}: " + navInfo.FormatAnnouncement();
                 
                 MelonLogger.Msg($"[SMART NAV] {announcement}");
                 TolkScreenReader.Instance.Speak(announcement, true);
@@ -62,13 +85,159 @@ namespace AccessibilityMod.Navigation
             }
         }
 
+        public void FocusWaypoints()
+        {
+            if (IsWaypointNamingActive)
+            {
+                TolkScreenReader.Instance.Speak("Finish naming your waypoint first. Press Enter to save or Escape to cancel.", true);
+                return;
+            }
+
+            currentFocus = NavigationFocus.Waypoints;
+
+            string sceneKey = GetActiveSceneKey();
+            if (!waypointManager.HasWaypointsInScene(sceneKey))
+            {
+                string message = waypointManager.HasAnyWaypoints
+                    ? "No waypoints saved for this area. Press Alt plus Left Bracket to create one here."
+                    : "No waypoints saved yet. Press Alt plus Left Bracket to create one.";
+                TolkScreenReader.Instance.Speak(message, true);
+                return;
+            }
+
+            waypointManager.EnsureSelection(sceneKey);
+            AnnounceWaypointSelection(sceneKey, includeCategoryIntro: true);
+        }
+
+        public void StartWaypointCreation()
+        {
+            if (IsWaypointNamingActive)
+            {
+                TolkScreenReader.Instance.Speak("Already naming a waypoint. Press Enter to confirm or Escape to cancel.", true);
+                return;
+            }
+
+            Vector3 playerPos = GameObjectUtils.GetPlayerPosition();
+            if (playerPos == Vector3.zero)
+            {
+                TolkScreenReader.Instance.Speak("Could not capture player position for waypoint.", true);
+                return;
+            }
+
+            string sceneKey = GetActiveSceneKey();
+            string defaultName = waypointManager.GetDefaultName(sceneKey);
+            namingSession = new WaypointNamingSession(
+                playerPos,
+                defaultName,
+                sceneKey,
+                OnWaypointNamingCompleted,
+                OnWaypointNamingCancelled);
+
+            TolkScreenReader.Instance.Speak($"Creating waypoint. Type a name, then press Enter to save. Press Escape to cancel. Default is {defaultName}.", true);
+        }
+
+        public void HandleWaypointNamingInput(string inputCharacters)
+        {
+            namingSession?.HandleInput(inputCharacters);
+        }
+
+        public void ConfirmWaypointNaming()
+        {
+            namingSession?.Confirm();
+        }
+
+        public void CancelWaypointNaming()
+        {
+            namingSession?.Cancel();
+        }
+
+        public void DeleteCurrentWaypoint()
+        {
+            if (IsWaypointNamingActive)
+            {
+                TolkScreenReader.Instance.Speak("Finish naming your waypoint first. Press Enter to save or Escape to cancel.", true);
+                return;
+            }
+
+            string sceneKey = GetActiveSceneKey();
+
+            if (currentFocus != NavigationFocus.Waypoints)
+            {
+                if (!waypointManager.HasAnyWaypoints)
+                {
+                    string message = "No waypoints saved yet. Press Alt plus Left Bracket to create one.";
+                    TolkScreenReader.Instance.Speak(message, true);
+                }
+                else
+                {
+                    TolkScreenReader.Instance.Speak("Focus waypoints first with Ctrl plus Left Bracket, then press Alt plus Right Bracket to delete.", true);
+                }
+                return;
+            }
+
+            if (!waypointManager.TryGetSelection(sceneKey, out var waypoint, out _, out _))
+            {
+                string message = waypointManager.HasAnyWaypoints
+                    ? "No waypoints saved for this area. Press Alt plus Left Bracket to create one here."
+                    : "No waypoints saved yet. Press Alt plus Left Bracket to create one.";
+                TolkScreenReader.Instance.Speak(message, true);
+                return;
+            }
+
+            string deletedName = waypoint.Name;
+            if (!waypointManager.RemoveWaypoint(sceneKey, waypoint))
+            {
+                MelonLogger.Error("[WAYPOINTS] Failed to delete waypoint.");
+                TolkScreenReader.Instance.Speak("Could not delete waypoint.", true);
+                return;
+            }
+
+            MelonLogger.Msg($"[WAYPOINTS] Deleted waypoint {deletedName}");
+
+            if (!waypointManager.HasWaypointsInScene(sceneKey))
+            {
+                TolkScreenReader.Instance.Speak($"Deleted waypoint {deletedName}. No waypoints saved for this area.", true);
+                return;
+            }
+
+            waypointManager.EnsureSelection(sceneKey);
+            AnnounceWaypointSelection(sceneKey, includeCategoryIntro: true, prefix: $"Deleted waypoint {deletedName}.");
+        }
+
         public void CycleWithinCategory(bool backward = false)
         {
+            if (IsWaypointNamingActive)
+            {
+                TolkScreenReader.Instance.Speak("Finish naming your waypoint first.", true);
+                return;
+            }
+
             try
             {
+                if (currentFocus == NavigationFocus.Waypoints)
+                {
+                    string sceneKey = GetActiveSceneKey();
+                    if (!waypointManager.HasWaypointsInScene(sceneKey))
+                    {
+                        string message = waypointManager.HasAnyWaypoints
+                            ? "No waypoints saved for this area. Press Alt plus Left Bracket to create one here."
+                            : "No waypoints saved yet. Press Alt plus Left Bracket to create one.";
+                        TolkScreenReader.Instance.Speak(message, true);
+                        return;
+                    }
+
+                    if (backward)
+                        waypointManager.SelectPrevious(sceneKey);
+                    else
+                        waypointManager.SelectNext(sceneKey);
+
+                    AnnounceWaypointSelection(sceneKey, includeCategoryIntro: false);
+                    return;
+                }
+
                 if (!stateManager.HasSelection)
                 {
-                    TolkScreenReader.Instance.Speak("No objects in current category. Press [ for NPCs, ] for locations, \\ for containers, or = for everything.", true);
+                    TolkScreenReader.Instance.Speak("No objects in current category. Press [ for NPCs, ] for locations, \\ for containers, = for everything, or Ctrl plus [ for waypoints.", true);
                     return;
                 }
 
@@ -98,8 +267,33 @@ namespace AccessibilityMod.Navigation
 
         public void NavigateToSelectedObject()
         {
+            if (IsWaypointNamingActive)
+            {
+                TolkScreenReader.Instance.Speak("Finish naming your waypoint first.", true);
+                return;
+            }
+
             try
             {
+                if (currentFocus == NavigationFocus.Waypoints)
+                {
+                    string sceneKey = GetActiveSceneKey();
+                    if (!waypointManager.TryGetSelection(sceneKey, out var waypoint, out _, out _))
+                    {
+                        string message = waypointManager.HasAnyWaypoints
+                            ? "No waypoints saved for this area. Press Alt plus Left Bracket to create one here."
+                            : "No waypoints saved yet. Press Alt plus Left Bracket to create one.";
+                        TolkScreenReader.Instance.Speak(message, true);
+                        return;
+                    }
+
+                    MelonLogger.Msg($"[WAYPOINTS] Navigating to waypoint {waypoint.Name}");
+                    TolkScreenReader.Instance.Speak($"Calculating path to waypoint {waypoint.Name}...", true);
+
+                    movementController.TryNavigateToPosition(waypoint.Position, $"waypoint {waypoint.Name}");
+                    return;
+                }
+
                 var selectedObject = stateManager.GetCurrentSelectedObject();
                 if (selectedObject == null || selectedObject.transform == null)
                 {
@@ -135,6 +329,18 @@ namespace AccessibilityMod.Navigation
 
         public void ToggleSortingMode()
         {
+            if (IsWaypointNamingActive)
+            {
+                TolkScreenReader.Instance.Speak("Finish naming your waypoint first.", true);
+                return;
+            }
+
+            if (currentFocus == NavigationFocus.Waypoints)
+            {
+                TolkScreenReader.Instance.Speak("Sorting only applies to object categories. Press [ to switch back to NPCs or Ctrl plus [ for waypoints.", true);
+                return;
+            }
+
             try
             {
                 stateManager.ToggleSortingMode();
@@ -202,29 +408,25 @@ namespace AccessibilityMod.Navigation
                     if (obj == null || obj.transform == null) continue;
                     
                     float distance = Vector3.Distance(playerPos, obj.transform.position);
-                    string objName = ObjectNameCleaner.GetBetterObjectName(obj);
+                    string name = ObjectNameCleaner.GetBetterObjectName(obj);
                     
                     if (distance > maxDistance)
                     {
                         maxDistance = distance;
-                        furthestObject = objName;
+                        furthestObject = name;
                     }
-                    
+
                     if (distance < minDistance)
                     {
                         minDistance = distance;
-                        nearestObject = objName;
+                        nearestObject = name;
                     }
-                    
-                    if (distance > 20.0f)
-                    {
+
+                    if (distance > 20f)
                         objectsOver20m++;
-                    }
-                    
-                    MelonLogger.Msg($"[REGISTRY TEST] Object: {objName} at distance {distance:F1}m");
                 }
                 
-                // Test 4: Compare to selection manager's limited range
+                // Check interactable selection manager
                 var selectionManager = UnityEngine.Object.FindObjectOfType<CharacterAnalogueControl>();
                 int nearbyOnly = 0;
                 if (selectionManager != null && selectionManager.m_interactableSelectionManager != null)
@@ -328,5 +530,176 @@ namespace AccessibilityMod.Navigation
                 TolkScreenReader.Instance.Speak($"Distance scan failed: {ex.Message}", true);
             }
         }
+
+        private string GetActiveSceneKey()
+        {
+            try
+            {
+                var player = GameObjectUtils.GetPlayerCharacter();
+                if (player != null)
+                {
+                    string playerKey = BuildPlayerSceneKey(player);
+                    if (!string.IsNullOrEmpty(playerKey))
+                        return playerKey;
+                }
+
+                var activeScene = SceneManager.GetActiveScene();
+                if (activeScene.IsValid())
+                {
+                    if (!string.IsNullOrEmpty(activeScene.path))
+                        return activeScene.path;
+                    if (!string.IsNullOrEmpty(activeScene.name))
+                        return activeScene.name;
+                }
+            }
+            catch (Exception ex)
+            {
+                MelonLogger.Error($"[WAYPOINTS] Failed to determine active scene key: {ex}");
+            }
+
+            return "UnknownScene";
+        }
+
+        private string BuildPlayerSceneKey(Character player)
+        {
+            try
+            {
+                var scene = player.gameObject.scene;
+                string baseKey = scene.IsValid()
+                    ? (!string.IsNullOrEmpty(scene.path) ? scene.path : scene.name)
+                    : null;
+
+                string locationHint = TryGetLocationHint(player.transform);
+                if (!string.IsNullOrEmpty(locationHint))
+                {
+                    if (string.IsNullOrEmpty(baseKey))
+                        return locationHint;
+                    return $"{baseKey}|{locationHint}";
+                }
+
+                return baseKey;
+            }
+            catch (Exception ex)
+            {
+                MelonLogger.Error($"[WAYPOINTS] Failed to build player scene key: {ex}");
+                return null;
+            }
+        }
+
+        private string TryGetLocationHint(Transform transform)
+        {
+            if (transform == null)
+                return null;
+
+            var candidates = new List<string>();
+            Transform current = transform.parent;
+            int depth = 0;
+
+            while (current != null && depth < 8)
+            {
+                string name = current.name;
+                if (!string.IsNullOrWhiteSpace(name) && !IsGenericTransformName(name))
+                {
+                    if (IsLocationNameCandidate(name))
+                    {
+                        return name;
+                    }
+
+                    if (!candidates.Contains(name))
+                    {
+                        candidates.Add(name);
+                    }
+                }
+
+                current = current.parent;
+                depth++;
+            }
+
+            return candidates.Count > 0 ? candidates[0] : null;
+        }
+
+        private bool IsLocationNameCandidate(string name)
+        {
+            string lower = name.ToLowerInvariant();
+            string[] keywords =
+            {
+                "interior", "exterior", "room", "shop", "store", "book", "whirling", "church",
+                "kitchen", "office", "station", "dock", "apartment", "basement", "yard", "hall", "gallery"
+            };
+
+            return keywords.Any(lower.Contains) || lower.EndsWith("_int") || lower.EndsWith("_ext");
+        }
+
+        private bool IsGenericTransformName(string name)
+        {
+            string lower = name.ToLowerInvariant();
+            string[] generic =
+            {
+                "root", "game", "scene", "characters", "character", "player", "harry", "armature", "skeleton", "hips"
+            };
+
+            if (generic.Any(g => lower == g))
+                return true;
+
+            return lower.StartsWith("char_") || lower.StartsWith("animation");
+        }
+
+        private void AnnounceWaypointSelection(string sceneKey, bool includeCategoryIntro, string prefix = null)
+        {
+            if (!waypointManager.TryGetSelection(sceneKey, out var waypoint, out int selectedIndex, out int totalCount))
+            {
+                string message = waypointManager.HasAnyWaypoints
+                    ? "No waypoints saved for this area. Press Alt plus Left Bracket to create one here."
+                    : "No waypoints saved yet. Press Alt plus Left Bracket to create one.";
+                TolkScreenReader.Instance.Speak(message, true);
+                return;
+            }
+
+            Vector3 playerPos = GameObjectUtils.GetPlayerPosition();
+            string controlsInstruction = "Press period to cycle, comma to navigate, Alt plus Right Bracket to delete.";
+            string announcement;
+
+            if (playerPos != Vector3.zero)
+            {
+                float distance = Vector3.Distance(playerPos, waypoint.Position);
+                string direction = DirectionCalculator.GetCardinalDirection(playerPos, waypoint.Position);
+                announcement = $"{waypoint.Name} {distance:F0} meters {direction}, {selectedIndex + 1} of {totalCount}. {controlsInstruction}";
+            }
+            else
+            {
+                announcement = $"{waypoint.Name}, {selectedIndex + 1} of {totalCount}. {controlsInstruction}";
+            }
+
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                announcement = $"{prefix} {announcement}";
+            }
+
+            if (includeCategoryIntro)
+            {
+                announcement = $"Waypoints: {announcement}";
+            }
+
+            MelonLogger.Msg($"[WAYPOINTS] {announcement}");
+            TolkScreenReader.Instance.Speak(announcement, true);
+        }
+
+        private void OnWaypointNamingCompleted(string finalName, Vector3 position, string sceneName, bool usedDefault)
+        {
+            namingSession = null;
+
+            waypointManager.AddWaypoint(position, finalName, sceneName);
+            currentFocus = NavigationFocus.Waypoints;
+
+            string prefix = $"Waypoint {finalName} saved.";
+            AnnounceWaypointSelection(sceneName, includeCategoryIntro: true, prefix: prefix);
+        }
+
+        private void OnWaypointNamingCancelled()
+        {
+            namingSession = null;
+            TolkScreenReader.Instance.Speak("Waypoint creation cancelled.", true);
+        }
     }
 }
+

--- a/mod/Navigation/WaypointManager.cs
+++ b/mod/Navigation/WaypointManager.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace AccessibilityMod.Navigation
+{
+    public class Waypoint
+    {
+        public Waypoint(Vector3 position, string name, string sceneName)
+        {
+            Position = position;
+            Name = name;
+            SceneName = sceneName;
+            CreatedAtUtc = DateTime.UtcNow;
+        }
+
+        public Vector3 Position { get; }
+        public string Name { get; private set; }
+        public string SceneName { get; }
+        public DateTime CreatedAtUtc { get; }
+
+        public void Rename(string newName)
+        {
+            if (!string.IsNullOrWhiteSpace(newName))
+                Name = newName.Trim();
+        }
+    }
+
+    public class WaypointManager
+    {
+        private readonly List<Waypoint> waypoints = new List<Waypoint>();
+        private readonly Dictionary<string, int> selectedIndicesByScene = new Dictionary<string, int>();
+
+        public IReadOnlyList<Waypoint> Waypoints => waypoints;
+        public int Count => waypoints.Count;
+
+        public bool HasAnyWaypoints => waypoints.Count > 0;
+
+        public string GetDefaultName(string sceneName)
+        {
+            int perSceneCount = GetWaypointsForScene(sceneName).Count;
+            return $"Waypoint {perSceneCount + 1}";
+        }
+
+        public Waypoint AddWaypoint(Vector3 position, string name, string sceneName)
+        {
+            var waypoint = new Waypoint(position, name, sceneName);
+            waypoints.Add(waypoint);
+
+            var sceneWaypoints = GetWaypointsForScene(sceneName);
+            selectedIndicesByScene[sceneName] = sceneWaypoints.Count - 1;
+
+            return waypoint;
+        }
+
+        public bool RemoveWaypoint(string sceneName, Waypoint waypoint)
+        {
+            if (waypoint == null)
+                return false;
+
+            string targetScene = string.IsNullOrEmpty(sceneName) ? waypoint.SceneName : sceneName;
+            if (string.IsNullOrEmpty(targetScene))
+                return waypoints.Remove(waypoint);
+
+            int previousIndex = selectedIndicesByScene.TryGetValue(targetScene, out int storedIndex) ? storedIndex : -1;
+            var sceneWaypointsBefore = GetWaypointsForScene(targetScene);
+            int removedSceneIndex = sceneWaypointsBefore.IndexOf(waypoint);
+
+            bool removed = waypoints.Remove(waypoint);
+            if (!removed)
+                return false;
+
+            var updatedSceneWaypoints = GetWaypointsForScene(targetScene);
+            if (updatedSceneWaypoints.Count == 0)
+            {
+                selectedIndicesByScene.Remove(targetScene);
+            }
+            else
+            {
+                int newIndex = removedSceneIndex >= 0 ? removedSceneIndex : previousIndex;
+                if (newIndex < 0)
+                    newIndex = 0;
+
+                newIndex = Mathf.Clamp(newIndex, 0, updatedSceneWaypoints.Count - 1);
+                selectedIndicesByScene[targetScene] = newIndex;
+            }
+
+            return true;
+        }
+
+        public bool HasWaypointsInScene(string sceneName)
+        {
+            return GetWaypointsForScene(sceneName).Count > 0;
+        }
+
+        public void EnsureSelection(string sceneName)
+        {
+            var sceneWaypoints = GetWaypointsForScene(sceneName);
+            if (sceneWaypoints.Count == 0)
+            {
+                selectedIndicesByScene.Remove(sceneName);
+                return;
+            }
+
+            int index = GetSelectedIndexForScene(sceneName, sceneWaypoints.Count);
+            selectedIndicesByScene[sceneName] = index;
+        }
+
+        public void SelectNext(string sceneName)
+        {
+            var sceneWaypoints = GetWaypointsForScene(sceneName);
+            if (sceneWaypoints.Count == 0) return;
+
+            int index = GetSelectedIndexForScene(sceneName, sceneWaypoints.Count);
+            index = (index + 1) % sceneWaypoints.Count;
+            selectedIndicesByScene[sceneName] = index;
+        }
+
+        public void SelectPrevious(string sceneName)
+        {
+            var sceneWaypoints = GetWaypointsForScene(sceneName);
+            if (sceneWaypoints.Count == 0) return;
+
+            int index = GetSelectedIndexForScene(sceneName, sceneWaypoints.Count);
+            index = (index - 1 + sceneWaypoints.Count) % sceneWaypoints.Count;
+            selectedIndicesByScene[sceneName] = index;
+        }
+
+        public bool TryGetSelection(string sceneName, out Waypoint waypoint, out int index, out int total)
+        {
+            var sceneWaypoints = GetWaypointsForScene(sceneName);
+            total = sceneWaypoints.Count;
+
+            if (total == 0)
+            {
+                waypoint = null;
+                index = -1;
+                selectedIndicesByScene.Remove(sceneName);
+                return false;
+            }
+
+            index = GetSelectedIndexForScene(sceneName, total);
+            waypoint = sceneWaypoints[index];
+            return true;
+        }
+
+        private List<Waypoint> GetWaypointsForScene(string sceneName)
+        {
+            if (string.IsNullOrEmpty(sceneName))
+                return new List<Waypoint>();
+
+            return waypoints.Where(w => w.SceneName == sceneName).OrderBy(w => w.CreatedAtUtc).ToList();
+        }
+
+        private int GetSelectedIndexForScene(string sceneName, int totalCount)
+        {
+            if (totalCount == 0)
+                return -1;
+
+            if (!selectedIndicesByScene.TryGetValue(sceneName, out int index))
+            {
+                index = 0;
+            }
+
+            if (index < 0 || index >= totalCount)
+            {
+                index = Mathf.Clamp(index, 0, totalCount - 1);
+            }
+
+            selectedIndicesByScene[sceneName] = index;
+            return index;
+        }
+    }
+}

--- a/mod/Navigation/WaypointNamingSession.cs
+++ b/mod/Navigation/WaypointNamingSession.cs
@@ -1,0 +1,83 @@
+using System;
+using UnityEngine;
+
+namespace AccessibilityMod.Navigation
+{
+    internal class WaypointNamingSession
+    {
+        private readonly Vector3 position;
+        private readonly string defaultName;
+        private readonly string sceneName;
+        private readonly Action<string, Vector3, string, bool> onCompleted;
+        private readonly Action onCancelled;
+        private string currentInput = string.Empty;
+        private bool isActive = true;
+
+        public WaypointNamingSession(
+            Vector3 position,
+            string defaultName,
+            string sceneName,
+            Action<string, Vector3, string, bool> onCompleted,
+            Action onCancelled)
+        {
+            this.position = position;
+            this.defaultName = defaultName;
+            this.sceneName = sceneName;
+            this.onCompleted = onCompleted;
+            this.onCancelled = onCancelled;
+        }
+
+        public bool IsActive => isActive;
+        public string CurrentInput => currentInput;
+        public string DefaultName => defaultName;
+        public string SceneName => sceneName;
+
+        public void HandleInput(string inputCharacters)
+        {
+            if (!isActive || string.IsNullOrEmpty(inputCharacters))
+                return;
+
+            foreach (char character in inputCharacters)
+            {
+                if (character == '\b')
+                {
+                    if (currentInput.Length > 0)
+                    {
+                        currentInput = currentInput.Substring(0, currentInput.Length - 1);
+                    }
+                }
+                else if (character == '\r' || character == '\n')
+                {
+                    Confirm();
+                }
+                else if (!char.IsControl(character))
+                {
+                    if (currentInput.Length < 64)
+                    {
+                        currentInput += character;
+                    }
+                }
+            }
+        }
+
+        public void Confirm()
+        {
+            if (!isActive)
+                return;
+
+            isActive = false;
+            bool usedDefault = string.IsNullOrWhiteSpace(currentInput);
+            string finalName = usedDefault ? defaultName : currentInput.Trim();
+            onCompleted?.Invoke(finalName, position, sceneName, usedDefault);
+        }
+
+        public void Cancel()
+        {
+            if (!isActive)
+                return;
+
+            isActive = false;
+            onCancelled?.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated waypoint manager and naming session support so waypoints can be created, focused, or deleted without conflicting with category navigation
- wire Alt+Right Bracket to delete the currently selected waypoint and tighten speech prompts around waypoint actions
- improve waypoint announcements so players hear the new shortcut when browsing saved locations

## Testing
- dotnet build
